### PR TITLE
feat: support `pdm` and `poetry` as dependency or running instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Here is the list of default packages supported by this plugin, from [`db.py`](ht
 - [flakeheaven](https://github.com/flakeheaven/flakeheaven)
 - [isort](https://github.com/pycqa/isort)
 - [mypy](https://github.com/pre-commit/mirrors-mypy)
+- [pdm](https://github.com/pdm-project/pdm)
+- [poetry](https://github.com/python-poetry/poetry)
 - [pycln](https://github.com/hadialqattan/pycln)
 - [pyroma](https://github.com/regebro/pyroma)
 - [pyupgrade](https://github.com/asottile/pyupgrade)

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Here is the list of default packages supported by this plugin, from [`db.py`](ht
 - [yamllint](https://github.com/adrienverge/yamllint)
 <!-- END-GENERATED-PACKAGES-LIST -->
 
+> Note: `pdm` or `poetry` version will be added, from the current instance version, and not from the lockfile.
+
 ## Improvement ideas
 
 Feel free to open an issue or a PR if you have any idea, or if you want to help!

--- a/src/sync_pre_commit_lock/db.py
+++ b/src/sync_pre_commit_lock/db.py
@@ -63,6 +63,14 @@ DEPENDENCY_MAPPING: PackageRepoMapping = {
         "repo": "https://github.com/pre-commit/mirrors-mypy",
         "rev": "v${rev}",
     },
+    "pdm": {
+        "repo": "https://github.com/pdm-project/pdm",
+        "rev": "${rev}",
+    },
+    "poetry": {
+        "repo": "https://github.com/python-poetry/poetry",
+        "rev": "${rev}",
+    },
     "pycln": {
         "repo": "https://github.com/hadialqattan/pycln",
         "rev": "v${rev}",

--- a/src/sync_pre_commit_lock/pdm_plugin.py
+++ b/src/sync_pre_commit_lock/pdm_plugin.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, ClassVar, Union
 
 from pdm import termui
+from pdm.__version__ import __version__ as pdm_version
 from pdm.cli.commands.base import BaseCommand
 from pdm.cli.options import dry_run_option
 from pdm.signals import post_install, post_lock
@@ -142,6 +143,8 @@ def on_pdm_lock_check_pre_commit(
         for k, v in resolution.items()
         if (c := select_candidate(v)) and c.name and c.version
     }
+    # Adds pdm itself has it won't be part of the resolved dependencies
+    resolved_packages["pdm"] = GenericLockedPackage("pdm", pdm_version)
     action = SyncPreCommitHooksVersion(
         printer=printer,
         pre_commit_config_file_path=file_path,

--- a/src/sync_pre_commit_lock/poetry_plugin.py
+++ b/src/sync_pre_commit_lock/poetry_plugin.py
@@ -9,6 +9,7 @@ from cleo.events.console_terminate_event import ConsoleTerminateEvent
 from cleo.exceptions import CleoValueError
 from cleo.helpers import option
 from cleo.io.outputs.output import Verbosity
+from poetry.__version__ import __version__ as poetry_version
 from poetry.console.application import Application
 from poetry.console.commands.add import AddCommand
 from poetry.console.commands.install import InstallCommand
@@ -89,6 +90,8 @@ def run_sync_pre_commit_version(printer: PoetryPrinter, dry_run: bool, applicati
     locked_packages = {str(p.name): GenericLockedPackage(p.name, str(p.version)) for p in poetry_locked_packages}
     plugin_config = load_config(application.poetry.pyproject_path)
     file_path = Path().cwd() / plugin_config.pre_commit_config_file
+    # Add poetry itself as it won't be part of the resolved dependencies
+    locked_packages["poetry"] = GenericLockedPackage("poetry", poetry_version)
 
     SyncPreCommitHooksVersion(
         printer,


### PR DESCRIPTION
This PR adds support for both `pdm` and `poetry` themselves (they both expose `pre-commit` hooks).

Given they are both special cases (they are not in the resolved dependencies but the running tool in charge of the virtualenv and the dependencies), they are added from the running version.

This is especially useful for the lock-related hooks which are version dependent.