### PR TITLE
feat(sync): automatically update aliased repositories URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Feel free to open an issue or a PR if you have any idea, or if you want to help!
 - [ ] Check ref existence before writing?
 - [ ] New feature to convert from pre-commit online to local?
 - [ ] Warning if pre-commit CI auto update is also set?
-- [ ] Support automatic repository URL update (from legacy aliased repositories)
+- [x] Support automatic repository URL update (from legacy aliased repositories)
 
 
 ## Inspiration

--- a/src/sync_pre_commit_lock/actions/sync_hooks.py
+++ b/src/sync_pre_commit_lock/actions/sync_hooks.py
@@ -138,6 +138,9 @@ class SyncPreCommitHooksVersion:
         )
         return None
 
+    def get_pre_commit_repo_new_url(self, url: str) -> str:
+        return self.mapping[self.mapping_reverse_by_url[url]]["repo"]
+
     def get_pre_commit_repo_new_hooks(self, hooks: Sequence[PreCommitHook]) -> Sequence[PreCommitHook]:
         return [self.get_pre_commit_repo_new_hook(hook) for hook in hooks]
 
@@ -173,7 +176,7 @@ class SyncPreCommitHooksVersion:
                 continue
 
             new_repo = PreCommitRepo(
-                repo=pre_commit_repo.repo,
+                repo=self.get_pre_commit_repo_new_url(pre_commit_repo.repo),
                 rev=self.get_pre_commit_repo_new_version(pre_commit_repo) or pre_commit_repo.rev,
                 hooks=self.get_pre_commit_repo_new_hooks(pre_commit_repo.hooks),
             )

--- a/src/sync_pre_commit_lock/pdm_plugin.py
+++ b/src/sync_pre_commit_lock/pdm_plugin.py
@@ -17,6 +17,7 @@ from sync_pre_commit_lock import (
 from sync_pre_commit_lock.actions.install_hooks import SetupPreCommitHooks
 from sync_pre_commit_lock.actions.sync_hooks import GenericLockedPackage, SyncPreCommitHooksVersion
 from sync_pre_commit_lock.config import SyncPreCommitLockConfig, load_config
+from sync_pre_commit_lock.utils import url_diff
 
 if TYPE_CHECKING:
     import argparse
@@ -59,8 +60,9 @@ class PDMPrinter(Printer):
     def success(self, msg: str) -> None:
         self.ui.echo("[success]" + self.prefix_lines(msg) + "[/success]", verbosity=Verbosity.NORMAL)
 
-    def _format_repo_url(self, repo_url: str, package_name: str) -> str:
-        return repo_url.replace(package_name, f"[cyan][bold]{package_name}[/bold][/cyan]")
+    def _format_repo_url(self, old_repo_url: str, new_repo_url: str, package_name: str) -> str:
+        url = url_diff(old_repo_url, new_repo_url, "[cyan]{[/][red]", "[/red][cyan] -> [/][green]", "[/][cyan]}[/]")
+        return url.replace(package_name, f"[cyan][bold]{package_name}[/bold][/cyan]")
 
     def list_updated_packages(self, packages: dict[str, tuple[PreCommitRepo, PreCommitRepo]]) -> None:
         """
@@ -75,7 +77,7 @@ class PDMPrinter(Printer):
         new_version = new.rev != old.rev
         repo = (
             f"[info]{self.plugin_prefix}[/info] {self.success_list_token}",
-            f"[info]{self._format_repo_url(old.repo, package)}[/info]",
+            f"[info]{self._format_repo_url(old.repo, new.repo, package)}[/info]",
             " ",
             f"[error]{old.rev}[/error]" if new_version else "",
             "[info]->[/info]" if new_version else "",

--- a/src/sync_pre_commit_lock/poetry_plugin.py
+++ b/src/sync_pre_commit_lock/poetry_plugin.py
@@ -23,6 +23,7 @@ from sync_pre_commit_lock import Printer
 from sync_pre_commit_lock.actions.install_hooks import SetupPreCommitHooks
 from sync_pre_commit_lock.actions.sync_hooks import GenericLockedPackage, SyncPreCommitHooksVersion
 from sync_pre_commit_lock.config import load_config
+from sync_pre_commit_lock.utils import url_diff
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -71,7 +72,7 @@ class PoetryPrinter(Printer):
         new_version = new.rev != old.rev
         repo = (
             f"<info>{self.plugin_prefix} {self.success_list_token}",
-            self._format_repo_url(old.repo, package),
+            self._format_repo_url(old.repo, new.repo, package),
             " ",
             f"<warning>{old.rev}</>" if new_version else "",
             "->" if new_version else "",
@@ -85,8 +86,9 @@ class PoetryPrinter(Printer):
         ]
         return [repo, *hooks] if hooks else [repo]
 
-    def _format_repo_url(self, repo_url: str, package_name: str) -> str:
-        return repo_url.replace(package_name, f"<c1>{package_name}</>")
+    def _format_repo_url(self, old_repo_url: str, new_repo_url: str, package_name: str) -> str:
+        url = url_diff(old_repo_url, new_repo_url, "<c1>{</><warning>", "</><c1> -> </><success>", "</><c1>}</>")
+        return url.replace(package_name, f"<c1>{package_name}</>")
 
     def _format_hook(self, old: PreCommitHook, new: PreCommitHook, last: bool) -> Sequence[Sequence[str]]:
         if not (nb_deps := len(old.additional_dependencies)):

--- a/src/sync_pre_commit_lock/utils.py
+++ b/src/sync_pre_commit_lock/utils.py
@@ -1,3 +1,4 @@
+from os.path import commonprefix
 from urllib.parse import urlparse, urlunparse
 
 
@@ -38,3 +39,14 @@ def normalize_git_url(url: str) -> str:
         normalized_url = normalized_url[:-1]
 
     return normalized_url
+
+
+def url_diff(old: str, new: str, diff_open: str = "{", diff_separator: str = " -> ", diff_close: str = "}") -> str:
+    """Represent a change of URL highliting only the changed part"""
+    if old == new:
+        return new
+    prefix = commonprefix((old, new))
+    old, new = old.removeprefix(prefix), new.removeprefix(prefix)
+    suffix = commonprefix((old[::-1], new[::-1]))[::-1]
+    old, new = old.removesuffix(suffix), new.removesuffix(suffix)
+    return f"{prefix}{diff_open}{old}{diff_separator}{new}{diff_close}{suffix}"

--- a/src/sync_pre_commit_lock/utils.py
+++ b/src/sync_pre_commit_lock/utils.py
@@ -42,7 +42,7 @@ def normalize_git_url(url: str) -> str:
 
 
 def url_diff(old: str, new: str, diff_open: str = "{", diff_separator: str = " -> ", diff_close: str = "}") -> str:
-    """Represent a change of URL highliting only the changed part"""
+    """Represent a change of URL highlighting only the changed part"""
     if old == new:
         return new
     prefix = commonprefix((old, new))

--- a/tests/test_pdm/test_pdm_plugin.py
+++ b/tests/test_pdm/test_pdm_plugin.py
@@ -151,3 +151,19 @@ def test_pdm_printer_list_success_repo_with_multiple_hooks_and_additional_depend
     assert "[sync-pre-commit-lock]    └ 2nd-hook" in captured.out
     assert "[sync-pre-commit-lock]      ├ dep                    *      -> 0.1.2" in captured.out
     assert "[sync-pre-commit-lock]      └ other                  >=0.42 -> 3.4.5" in captured.out
+
+
+def test_pdm_printer_list_success_renamed_repository(capsys: pytest.CaptureFixture[str]) -> None:
+    printer = PDMPrinter(UI())
+
+    printer.list_updated_packages(
+        {
+            "package": (
+                PreCommitRepo("https://old.repo.local/test", "rev1", [PreCommitHook("hook")]),
+                PreCommitRepo("https://new.repo.local/test", "rev2", [PreCommitHook("hook")]),
+            ),
+        }
+    )
+    captured = capsys.readouterr()
+
+    assert "[sync-pre-commit-lock]  ✔ https://{old -> new}.repo.local/test   rev1 -> rev2" in captured.out

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sync_pre_commit_lock.utils import normalize_git_url
+from sync_pre_commit_lock.utils import normalize_git_url, url_diff
 
 
 # Here are the test cases
@@ -23,3 +23,17 @@ from sync_pre_commit_lock.utils import normalize_git_url
 )
 def test_normalize_git_url(url: str, expected: str) -> None:
     assert normalize_git_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "old,new,expected",
+    [
+        ("https://some.place", "https://some.place", "https://some.place"),
+        ("https://some.old.place", "https://some.new.place", "https://some.{old -> new}.place"),
+        ("https://some.place", "https://another.place", "https://{some -> another}.place"),
+        ("https://some.place/old", "https://a.different/place", "https://{some.place/old -> a.different/place}"),
+        ("https://some.place/old", "https://some.place/new", "https://some.place/{old -> new}"),
+    ],
+)
+def test_url_diff(old: str, new: str, expected: str):
+    assert url_diff(old, new) == expected


### PR DESCRIPTION
This PR adds support for automatic URL update of moved repositories.

The idea is that aliased URLs are old URLs of a repository which moved (or recommend another URL like for black).
So this PR consider a repository to an aliased URL need an update and change it to the last known URL.

Attention has been ported to presentation to avoid crowding the terminal.
Here's my proposal

### PDM
![image](https://github.com/user-attachments/assets/ec64c985-a78b-41b2-8995-455ba392685b)

### Poetry
![image](https://github.com/user-attachments/assets/af11f0d5-d2a2-4d69-84ae-0fd895a85cc1)

