### PR TITLE
db: add djade pre-commit to default associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Here is the list of default packages supported by this plugin, from [`db.py`](ht
 - [check-jsonschema](https://github.com/python-jsonschema/check-jsonschema)
 - [codespell](https://github.com/codespell-project/codespell)
 - [commitizen](https://github.com/commitizen-tools/commitizen)
+- [djade](https://github.com/adamchainz/djade-pre-commit)
 - [djhtml](https://github.com/rtts/djhtml)
 - [docformatter](https://github.com/PyCQA/docformatter)
 - [flake8](https://github.com/pycqa/flake8)

--- a/src/sync_pre_commit_lock/db.py
+++ b/src/sync_pre_commit_lock/db.py
@@ -39,6 +39,10 @@ DEPENDENCY_MAPPING: PackageRepoMapping = {
         "repo": "https://github.com/commitizen-tools/commitizen",
         "rev": "v${rev}",
     },
+    "djade": {
+        "repo": "https://github.com/adamchainz/djade-pre-commit",
+        "rev": "${rev}",
+    },
     "djhtml": {
         "repo": "https://github.com/rtts/djhtml",
         "rev": "${rev}",


### PR DESCRIPTION
- Add https://github.com/adamchainz/djade-pre-commit to default associations.