### PR TITLE
feat(prek): support `prek` as hook runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ ignore = []
 # Name of the pre-commit config file to sync with
 # Can be set to ".pre-commit-config.yml" to support prek alternate config file
 pre-commit-config-file = ".pre-commit-config.yaml"
+# Hook runner to use for installing hooks: "pre-commit", "prek", or "auto"
+# "auto" tries prek first, then falls back to pre-commit
+hook-runner = "pre-commit"
 # Additional mapping of URLs to python packages
 # Default is empty, but will merge with the default mapping
 # "rev" indicates the format of the Git tags
@@ -103,12 +106,13 @@ dependency-mapping = {"package-name"= {"repo"= "https://github.com/example/packa
 
 Some settings are overridable by environment variables with the following `SYNC_PRE_COMMIT_LOCK_*` prefixed environment variables:
 
-| `toml` setting                | environment                            | format                            |
-| ----------------------------- | -------------------------------------- | --------------------------------- |
-| `automatically-install-hooks` | `SYNC_PRE_COMMIT_LOCK_INSTALL`         | `bool` as string (`true`, `1`...) |
-| `disable-sync-from-lock`      | `SYNC_PRE_COMMIT_LOCK_DISABLED`        | `bool` as string (`true`, `1`...) |
-| `ignore`                      | `SYNC_PRE_COMMIT_LOCK_IGNORE`          | comma-separated list              |
-| `pre-commit-config-file`      | `SYNC_PRE_COMMIT_LOCK_PRE_COMMIT_FILE` | `str`                             |
+| `toml` setting                | environment                            | format                                      |
+| ----------------------------- | -------------------------------------- | ------------------------------------------- |
+| `automatically-install-hooks` | `SYNC_PRE_COMMIT_LOCK_INSTALL`         | `bool` as string (`true`, `1`...)           |
+| `disable-sync-from-lock`      | `SYNC_PRE_COMMIT_LOCK_DISABLED`        | `bool` as string (`true`, `1`...)           |
+| `ignore`                      | `SYNC_PRE_COMMIT_LOCK_IGNORE`          | comma-separated list                        |
+| `pre-commit-config-file`      | `SYNC_PRE_COMMIT_LOCK_PRE_COMMIT_FILE` | `str`                                       |
+| `hook-runner`                 | `SYNC_PRE_COMMIT_LOCK_HOOK_RUNNER`     | `str` (`pre-commit`, `prek`, or `auto`)     |
 
 ## Usage
 

--- a/src/sync_pre_commit_lock/actions/install_hooks.py
+++ b/src/sync_pre_commit_lock/actions/install_hooks.py
@@ -7,23 +7,75 @@ import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
+from sync_pre_commit_lock.config import HookRunner
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from sync_pre_commit_lock import Printer
 
 
-class SetupPreCommitHooks:
-    install_pre_commit_hooks_command: ClassVar[Sequence[str | bytes]] = ["pre-commit", "install"]
-    check_pre_commit_version_command: ClassVar[Sequence[str | bytes]] = ["pre-commit", "--version"]
+class ResolvedHookRunner:
+    """A resolved hook runner, bound to a concrete runner (never AUTO) and a command prefix."""
 
-    def __init__(self, printer: Printer, dry_run: bool = False) -> None:
+    # Probe order for auto-detection: try prek first, then pre-commit
+    _AUTO_ORDER: ClassVar[tuple[HookRunner, ...]] = (HookRunner.PREK, HookRunner.PRE_COMMIT)
+
+    def __init__(self, runner: HookRunner, command_prefix: Sequence[str] = ()) -> None:
+        self.runner = runner
+        self.command_prefix = command_prefix
+
+    @property
+    def name(self) -> str:
+        return self.runner.value
+
+    def execute(self, *args: str) -> Sequence[str | bytes]:
+        return [*self.command_prefix, self.runner.value, *args]
+
+    def is_installed(self) -> bool:
+        """Check if this runner is installed by running its --version command."""
+        try:
+            output = subprocess.check_output(self.execute("--version")).decode()  # noqa: S603
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return False
+        else:
+            return self.runner.value in output
+
+    @classmethod
+    def resolve(
+        cls,
+        hook_runner: HookRunner,
+        command_prefix: Sequence[str] = (),
+        printer: Printer | None = None,
+    ) -> ResolvedHookRunner | None:
+        """Resolve a HookRunner config to a concrete ResolvedHookRunner, or None if not found."""
+        candidates = cls._AUTO_ORDER if hook_runner is HookRunner.AUTO else [hook_runner]
+        for candidate in candidates:
+            runner = cls(candidate, command_prefix)
+            if runner.is_installed():
+                if hook_runner is HookRunner.AUTO and printer:
+                    printer.debug(f"Auto-detected hook runner: {candidate.value}")
+                return runner
+        return None
+
+
+class SetupPreCommitHooks:
+    command_prefix: ClassVar[Sequence[str]] = ()
+
+    def __init__(
+        self,
+        printer: Printer,
+        dry_run: bool = False,
+        hook_runner: HookRunner = HookRunner.PRE_COMMIT,
+    ) -> None:
         self.printer = printer
         self.dry_run = dry_run
+        self.hook_runner = hook_runner
 
     def execute(self) -> None:
-        if not self._is_pre_commit_package_installed():
-            self.printer.debug("pre-commit package is not installed (or detected). Skipping.")
+        runner = ResolvedHookRunner.resolve(self.hook_runner, self.command_prefix, self.printer)
+        if runner is None:
+            self.printer.debug("No hook runner (pre-commit or prek) is installed (or detected). Skipping.")
             return
 
         git_root = self._get_git_directory_path()
@@ -39,35 +91,24 @@ class SetupPreCommitHooks:
             self.printer.debug("Dry run, skipping pre-commit hook installation.")
             return
 
-        self._install_pre_commit_hooks()
+        self._install_hooks(runner)
 
-    def _install_pre_commit_hooks(self) -> None:
+    def _install_hooks(self, runner: ResolvedHookRunner) -> None:
         try:
-            self.printer.info("Installing pre-commit hooks...")
+            self.printer.info(f"Installing {runner.name} hooks...")
             return_code = subprocess.check_call(  # noqa: S603
-                self.install_pre_commit_hooks_command,
+                runner.execute("install"),
                 # XXX We probably want to see the output, at least in verbose mode or if it fails
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )
             if return_code == 0:
-                self.printer.info("pre-commit hooks successfully installed!")
+                self.printer.info(f"{runner.name} hooks successfully installed!")
             else:
-                self.printer.error("Failed to install pre-commit hooks")
+                self.printer.error(f"Failed to install {runner.name} hooks")
         except Exception as e:
-            self.printer.error("Failed to install pre-commit hooks due to an unexpected error")
+            self.printer.error(f"Failed to install {runner.name} hooks due to an unexpected error")
             self.printer.error(f"{e}")
-
-    def _is_pre_commit_package_installed(self) -> bool:
-        try:
-            # Try is `pre-commit --version` works
-            output = subprocess.check_output(  # noqa: S603
-                self.check_pre_commit_version_command,
-            ).decode()
-        except (subprocess.CalledProcessError, FileNotFoundError):
-            return False
-        else:
-            return "pre-commit" in output
 
     @staticmethod
     def _are_pre_commit_hooks_installed(git_root: Path) -> bool:

--- a/src/sync_pre_commit_lock/config.py
+++ b/src/sync_pre_commit_lock/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, TypedDict
 
@@ -9,6 +10,15 @@ from ._compat import toml
 
 if TYPE_CHECKING:
     from sync_pre_commit_lock.db import PackageRepoMapping
+
+
+class HookRunner(str, Enum):
+    """The hook runner to use for installing git hooks."""
+
+    PRE_COMMIT = "pre-commit"
+    PREK = "prek"
+    AUTO = "auto"
+
 
 ENV_PREFIX = "SYNC_PRE_COMMIT_LOCK"
 
@@ -73,6 +83,10 @@ class SyncPreCommitLockConfig:
     dependency_mapping: PackageRepoMapping = field(
         default_factory=dict,
         metadata=Metadata(toml="dependency-mapping"),
+    )
+    hook_runner: HookRunner = field(
+        default=HookRunner.PRE_COMMIT,
+        metadata=Metadata(toml="hook-runner", env="HOOK_RUNNER", cast=HookRunner),
     )
 
 

--- a/src/sync_pre_commit_lock/pdm_plugin.py
+++ b/src/sync_pre_commit_lock/pdm_plugin.py
@@ -132,8 +132,7 @@ def register_pdm_plugin(core: Core) -> None:
 
 
 class PDMSetupPreCommitHooks(SetupPreCommitHooks):
-    install_pre_commit_hooks_command: ClassVar[Sequence[str | bytes]] = ["pdm", "run", "pre-commit", "install"]
-    check_pre_commit_version_command: ClassVar[Sequence[str | bytes]] = ["pdm", "run", "pre-commit", "--version"]
+    command_prefix: ClassVar[Sequence[str]] = ("pdm", "run")
 
 
 class PDMSyncPreCommitHooksVersion(SyncPreCommitHooksVersion):
@@ -150,7 +149,7 @@ def on_pdm_install_setup_pre_commit(project: Project, *, dry_run: bool, **_: Any
     if not plugin_config.automatically_install_hooks:
         printer.debug("Automatically installing pre-commit hooks is disabled. Skipping.")
         return
-    action = PDMSetupPreCommitHooks(printer, dry_run=dry_run)
+    action = PDMSetupPreCommitHooks(printer, dry_run=dry_run, hook_runner=plugin_config.hook_runner)
     file_path = project.root / plugin_config.pre_commit_config_file
     if not file_path.exists():
         printer.info("No pre-commit config file found, skipping pre-commit hook check")

--- a/src/sync_pre_commit_lock/poetry_plugin.py
+++ b/src/sync_pre_commit_lock/poetry_plugin.py
@@ -136,8 +136,7 @@ class PoetryPrinter(Printer):
 
 
 class PoetrySetupPreCommitHooks(SetupPreCommitHooks):
-    install_pre_commit_hooks_command: ClassVar[Sequence[str | bytes]] = ["poetry", "run", "pre-commit", "install"]
-    check_pre_commit_version_command: ClassVar[Sequence[str | bytes]] = ["poetry", "run", "pre-commit", "--version"]
+    command_prefix: ClassVar[Sequence[str]] = ("poetry", "run")
 
 
 def run_sync_pre_commit_version(printer: PoetryPrinter, dry_run: bool, application: Application) -> None:
@@ -186,7 +185,8 @@ class SyncPreCommitLockPlugin(ApplicationPlugin):
             return
 
         if any(isinstance(command, t) for t in [InstallCommand, AddCommand]):
-            PoetrySetupPreCommitHooks(printer, dry_run=dry_run).execute()
+            plugin_config = load_config(self.application.poetry.pyproject_path) if self.application else load_config()
+            PoetrySetupPreCommitHooks(printer, dry_run=dry_run, hook_runner=plugin_config.hook_runner).execute()
 
         if any(isinstance(command, t) for t in [InstallCommand, AddCommand, LockCommand, UpdateCommand]):
             if self.application is None:

--- a/tests/test_actions/test_install_hooks.py
+++ b/tests/test_actions/test_install_hooks.py
@@ -6,121 +6,260 @@ import pytest
 from pytest_mock import MockerFixture
 
 from sync_pre_commit_lock import Printer
-from sync_pre_commit_lock.actions.install_hooks import SetupPreCommitHooks
+from sync_pre_commit_lock.actions.install_hooks import ResolvedHookRunner, SetupPreCommitHooks
+from sync_pre_commit_lock.config import HookRunner
+
+
+@pytest.fixture()
+def printer(mocker: MockerFixture) -> MagicMock:
+    return mocker.MagicMock()
+
+
+class TestResolvedHookRunner:
+    def test_name(self) -> None:
+        assert ResolvedHookRunner(HookRunner.PRE_COMMIT).name == "pre-commit"
+        assert ResolvedHookRunner(HookRunner.PREK).name == "prek"
+
+    @pytest.mark.parametrize(
+        ("runner", "prefix", "arg", "expected"),
+        [
+            (HookRunner.PRE_COMMIT, (), "install", ["pre-commit", "install"]),
+            (HookRunner.PRE_COMMIT, (), "--version", ["pre-commit", "--version"]),
+            (HookRunner.PREK, (), "install", ["prek", "install"]),
+            (HookRunner.PREK, (), "--version", ["prek", "--version"]),
+            (HookRunner.PRE_COMMIT, ("pdm", "run"), "install", ["pdm", "run", "pre-commit", "install"]),
+            (HookRunner.PRE_COMMIT, ("pdm", "run"), "--version", ["pdm", "run", "pre-commit", "--version"]),
+            (HookRunner.PREK, ("poetry", "run"), "install", ["poetry", "run", "prek", "install"]),
+            (HookRunner.PREK, ("poetry", "run"), "--version", ["poetry", "run", "prek", "--version"]),
+        ],
+    )
+    def test_execute(self, runner: HookRunner, prefix: tuple, arg: str, expected: list) -> None:
+        resolved = ResolvedHookRunner(runner, prefix)
+        assert list(resolved.execute(arg)) == expected
+
+    @pytest.mark.parametrize(
+        ("runner", "prefix", "subprocess_return", "expected"),
+        [
+            (HookRunner.PRE_COMMIT, (), b"pre-commit 2.9.3", True),
+            (HookRunner.PRE_COMMIT, (), FileNotFoundError(), False),
+            (HookRunner.PREK, (), b"prek 0.5.0", True),
+            (HookRunner.PREK, (), FileNotFoundError(), False),
+            (HookRunner.PREK, ("poetry", "run"), b"prek 0.5.0", True),
+        ],
+    )
+    def test_is_installed(
+        self, mocker: MockerFixture, runner: HookRunner, prefix: tuple, subprocess_return, expected: bool
+    ) -> None:
+        if isinstance(subprocess_return, Exception):
+            mocker.patch("subprocess.check_output", side_effect=subprocess_return)
+        else:
+            mocker.patch("subprocess.check_output", return_value=subprocess_return)
+        resolved = ResolvedHookRunner(runner, prefix)
+        assert resolved.is_installed() is expected
+
+    @pytest.mark.parametrize(
+        ("hook_runner", "subprocess_return", "expected_runner"),
+        [
+            (HookRunner.PRE_COMMIT, b"pre-commit 3.0.0", HookRunner.PRE_COMMIT),
+            (HookRunner.PRE_COMMIT, FileNotFoundError(), None),
+            (HookRunner.PREK, b"prek 0.5.0", HookRunner.PREK),
+        ],
+    )
+    def test_resolve_explicit(
+        self, printer, mocker: MockerFixture, hook_runner: HookRunner, subprocess_return, expected_runner
+    ) -> None:
+        if isinstance(subprocess_return, Exception):
+            mocker.patch("subprocess.check_output", side_effect=subprocess_return)
+        else:
+            mocker.patch("subprocess.check_output", return_value=subprocess_return)
+        resolved = ResolvedHookRunner.resolve(hook_runner, printer=printer)
+        if expected_runner is None:
+            assert resolved is None
+        else:
+            assert resolved is not None
+            assert resolved.runner is expected_runner
+
+    @pytest.mark.parametrize(
+        ("available_runners", "expected_runner"),
+        [
+            ({"prek": b"prek 0.5.0", "pre-commit": b"pre-commit 3.0.0"}, HookRunner.PREK),
+            ({"pre-commit": b"pre-commit 3.0.0"}, HookRunner.PRE_COMMIT),
+            ({}, None),
+        ],
+    )
+    def test_resolve_auto(self, printer, mocker: MockerFixture, available_runners: dict, expected_runner) -> None:
+        def mock_check_output(command, **kwargs):
+            for name, output in available_runners.items():
+                if command == [name, "--version"]:
+                    return output
+            raise FileNotFoundError
+
+        mocker.patch("subprocess.check_output", side_effect=mock_check_output)
+        resolved = ResolvedHookRunner.resolve(HookRunner.AUTO, printer=printer)
+        if expected_runner is None:
+            assert resolved is None
+        else:
+            assert resolved is not None
+            assert resolved.runner is expected_runner
+
+    def test_resolve_auto_with_prefix(self, printer, mocker: MockerFixture) -> None:
+        def mock_check_output(command, **kwargs):
+            if command == ["pdm", "run", "prek", "--version"]:
+                return b"prek 0.5.0"
+            raise FileNotFoundError
+
+        mocker.patch("subprocess.check_output", side_effect=mock_check_output)
+        resolved = ResolvedHookRunner.resolve(HookRunner.AUTO, command_prefix=("pdm", "run"), printer=printer)
+        assert resolved is not None
+        assert resolved.runner is HookRunner.PREK
+        assert list(resolved.execute("install")) == ["pdm", "run", "prek", "install"]
 
 
 class TestSetupPreCommitHooks:
     @pytest.fixture()
-    def printer(self, mocker: MockerFixture) -> MagicMock:
-        return mocker.MagicMock()
-
-    @pytest.fixture()
-    def mock_subprocess(self, mocker: MockerFixture) -> MagicMock:
-        return mocker.patch("subprocess.check_output", autospec=True)
-
-    @pytest.fixture()
     def mock_path_exists(self, mocker: MockerFixture) -> MagicMock:
         return mocker.patch.object(Path, "exists", autospec=True)
 
-    def test_execute_pre_commit_not_installed(self, printer: Printer, mock_subprocess: MagicMock):
-        mock_subprocess.return_value.decode.return_value = "fail"
+    def test_execute_no_runner(self, printer: Printer, mocker: MockerFixture):
+        mocker.patch.object(ResolvedHookRunner, "resolve", return_value=None)
         setup = SetupPreCommitHooks(printer, dry_run=False)
-        setup._is_pre_commit_package_installed = MagicMock(return_value=False)
         setup.execute()
         assert printer.debug.call_count == 1
-        assert printer.debug.call_args == call("pre-commit package is not installed (or detected). Skipping.")
+        assert printer.debug.call_args == call(
+            "No hook runner (pre-commit or prek) is installed (or detected). Skipping."
+        )
 
     def test_execute_not_in_git_repo(self, printer: MagicMock, mocker: MockerFixture) -> None:
+        mocker.patch.object(ResolvedHookRunner, "resolve", return_value=ResolvedHookRunner(HookRunner.PRE_COMMIT))
         mocker.patch(
             "subprocess.check_output", side_effect=subprocess.CalledProcessError(1, "git", b"error", b"output")
         )
         mocker.patch("subprocess.check_call", return_value=0)
 
         setup = SetupPreCommitHooks(printer, dry_run=False)
-        setup._is_pre_commit_package_installed = MagicMock(return_value=True)
         setup.execute()
         assert printer.debug.call_count == 3
         assert printer.debug.call_args == call("Not in a git repository - can't install hooks. Skipping.")
 
-    def test_execute_pre_commit_hooks_already_installed(
-        self, printer, mock_subprocess, mock_path_exists, mocker
-    ) -> None:
-        mock_subprocess.return_value.decode.return_value = "pre-commit"
+    def test_execute_hooks_already_installed(self, printer, mock_path_exists, mocker) -> None:
+        mocker.patch.object(ResolvedHookRunner, "resolve", return_value=ResolvedHookRunner(HookRunner.PRE_COMMIT))
         mocker.patch("subprocess.check_output", return_value=b"git_path")
         mock_path_exists.return_value = True
         setup = SetupPreCommitHooks(printer, dry_run=False)
-        # Mock _is_pre_commit_package_installed
-        setup._is_pre_commit_package_installed = MagicMock(return_value=True)
         setup.execute()
         assert printer.debug.call_count == 1
         assert printer.debug.call_args == call("pre-commit hooks already installed. Skipping.")
 
-    def test_execute_dry_run(self, printer, mock_subprocess, mock_path_exists, mocker) -> None:
-        mock_subprocess.return_value.decode.return_value = "pre-commit"
+    def test_execute_dry_run(self, printer, mock_path_exists, mocker) -> None:
+        mocker.patch.object(ResolvedHookRunner, "resolve", return_value=ResolvedHookRunner(HookRunner.PRE_COMMIT))
         mocker.patch("subprocess.check_output", return_value=b"git_path")
         mock_path_exists.return_value = False
         setup = SetupPreCommitHooks(printer, dry_run=True)
-        setup._is_pre_commit_package_installed = MagicMock(return_value=True)
         setup.execute()
         assert printer.debug.call_count == 1
         assert printer.debug.call_args == call("Dry run, skipping pre-commit hook installation.")
 
-    def test_execute_install_hooks(self, printer, mock_subprocess, mock_path_exists, mocker) -> None:
-        mock_subprocess.return_value.decode.return_value = "pre-commit"
+    def test_execute_install_hooks(self, printer, mock_path_exists, mocker) -> None:
+        mocker.patch.object(ResolvedHookRunner, "resolve", return_value=ResolvedHookRunner(HookRunner.PRE_COMMIT))
         mocker.patch("subprocess.check_output", return_value=b"git_path")
         mock_path_exists.return_value = False
         mocker.patch("subprocess.check_call", return_value=0)
         setup = SetupPreCommitHooks(printer, dry_run=False)
-        setup._is_pre_commit_package_installed = MagicMock(return_value=True)
         setup.execute()
         assert printer.info.call_count == 2
         printer.info.assert_has_calls(
             [call("Installing pre-commit hooks..."), call("pre-commit hooks successfully installed!")]
         )
 
-    def test_install_pre_commit_hooks_success(self, printer, mocker) -> None:
+    @pytest.mark.parametrize("hook_runner", [HookRunner.PRE_COMMIT, HookRunner.PREK])
+    def test_install_hooks_success(self, printer, mocker, hook_runner: HookRunner) -> None:
         mocked_check_call = mocker.patch("subprocess.check_call", return_value=0)
         setup = SetupPreCommitHooks(printer, dry_run=False)
-        setup._install_pre_commit_hooks()
+        resolved = ResolvedHookRunner(hook_runner)
+        setup._install_hooks(resolved)
+        name = hook_runner.value
         assert printer.info.call_count == 2
         printer.info.assert_has_calls(
-            [call("Installing pre-commit hooks..."), call("pre-commit hooks successfully installed!")]
+            [call(f"Installing {name} hooks..."), call(f"{name} hooks successfully installed!")]
         )
         mocked_check_call.assert_called_once()
 
-    def test_install_pre_commit_hooks_error(self, printer, mocker) -> None:
-        mocked_check_call = mocker.patch("subprocess.check_call", side_effect=subprocess.CalledProcessError(1, "cmd"))
+    @pytest.mark.parametrize("hook_runner", [HookRunner.PRE_COMMIT, HookRunner.PREK])
+    def test_install_hooks_error(self, printer, mocker, hook_runner: HookRunner) -> None:
+        mocker.patch("subprocess.check_call", side_effect=subprocess.CalledProcessError(1, "cmd"))
         setup = SetupPreCommitHooks(printer, dry_run=False)
-        setup._install_pre_commit_hooks()
+        resolved = ResolvedHookRunner(hook_runner)
+        setup._install_hooks(resolved)
+        name = hook_runner.value
         assert printer.info.call_count == 1
         assert printer.error.call_count == 2
-        printer.info.assert_has_calls([call("Installing pre-commit hooks...")])
+        printer.info.assert_has_calls([call(f"Installing {name} hooks...")])
         printer.error.assert_has_calls(
             [
-                call("Failed to install pre-commit hooks due to an unexpected error"),
+                call(f"Failed to install {name} hooks due to an unexpected error"),
                 call("Command 'cmd' returned non-zero exit status 1."),
             ]
         )
-        mocked_check_call.assert_called_once()
 
-    def test_is_pre_commit_package_installed_true(self, printer, mocker) -> None:
-        mocked_check_output = mocker.patch("subprocess.check_output", return_value=b"pre-commit 2.9.3")
+    @pytest.mark.parametrize("hook_runner", [HookRunner.PRE_COMMIT, HookRunner.PREK])
+    def test_install_hooks_non_zero_return_code(self, printer, mocker, hook_runner: HookRunner) -> None:
+        mocker.patch("subprocess.check_call", return_value=1)
         setup = SetupPreCommitHooks(printer, dry_run=False)
-        assert setup._is_pre_commit_package_installed() is True
-        mocked_check_output.assert_called_once()
-
-    def test_is_pre_commit_package_installed_error(self, printer, mocker) -> None:
-        mocked_check_output = mocker.patch("subprocess.check_output", side_effect=FileNotFoundError())
-        setup = SetupPreCommitHooks(printer, dry_run=False)
-        assert setup._is_pre_commit_package_installed() is False
-        mocked_check_output.assert_called_once()
-
-    def test_install_pre_commit_hooks_non_zero_return_code(self, printer, mocker) -> None:
-        mocked_check_call = mocker.patch("subprocess.check_call", return_value=1)
-        setup = SetupPreCommitHooks(printer, dry_run=False)
-        setup._install_pre_commit_hooks()
+        resolved = ResolvedHookRunner(hook_runner)
+        setup._install_hooks(resolved)
+        name = hook_runner.value
         assert printer.info.call_count == 1
         assert printer.error.call_count == 1
-        printer.info.assert_has_calls([call("Installing pre-commit hooks...")])
-        printer.error.assert_has_calls([call("Failed to install pre-commit hooks")])
-        mocked_check_call.assert_called_once()
+        printer.info.assert_has_calls([call(f"Installing {name} hooks...")])
+        printer.error.assert_has_calls([call(f"Failed to install {name} hooks")])
+
+
+class TestSetupPreCommitHooksAutoDetect:
+    @pytest.mark.parametrize(
+        ("available_runners", "expected_runner"),
+        [
+            ({"prek": b"prek 0.5.0"}, HookRunner.PREK),
+            ({"pre-commit": b"pre-commit 3.0.0"}, HookRunner.PRE_COMMIT),
+        ],
+        ids=["prek", "pre-commit-fallback"],
+    )
+    def test_auto_detect_execute_installs(
+        self, printer, mocker, available_runners: dict, expected_runner: HookRunner
+    ) -> None:
+        """Full execute flow with auto-detect resolving to the first available runner."""
+
+        def mock_check_output(command, **kwargs):
+            for name, output in available_runners.items():
+                if command == [name, "--version"]:
+                    return output
+            if command == ["git", "rev-parse", "--show-toplevel"]:
+                return b"/fake/repo"
+            raise FileNotFoundError
+
+        mocker.patch("subprocess.check_output", side_effect=mock_check_output)
+        mocker.patch.object(Path, "exists", return_value=False)
+        mocked_check_call = mocker.patch("subprocess.check_call", return_value=0)
+
+        setup = SetupPreCommitHooks(printer, dry_run=False, hook_runner=HookRunner.AUTO)
+        setup.execute()
+
+        name = expected_runner.value
+        mocked_check_call.assert_called_once_with(
+            [name, "install"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        printer.info.assert_has_calls(
+            [call(f"Installing {name} hooks..."), call(f"{name} hooks successfully installed!")]
+        )
+
+    def test_auto_detect_execute_none_available(self, printer, mocker) -> None:
+        """Full execute flow when no runner is available."""
+        mocker.patch("subprocess.check_output", side_effect=FileNotFoundError())
+
+        setup = SetupPreCommitHooks(printer, dry_run=False, hook_runner=HookRunner.AUTO)
+        setup.execute()
+
+        printer.debug.assert_called_once_with(
+            "No hook runner (pre-commit or prek) is installed (or detected). Skipping."
+        )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from sync_pre_commit_lock.config import SyncPreCommitLockConfig, from_toml, load_config, update_from_env
+from sync_pre_commit_lock.config import HookRunner, SyncPreCommitLockConfig, from_toml, load_config, update_from_env
 from sync_pre_commit_lock.db import RepoInfo
 
 
@@ -30,12 +30,14 @@ def test_update_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("SYNC_PRE_COMMIT_LOCK_INSTALL", "false")
     monkeypatch.setenv("SYNC_PRE_COMMIT_LOCK_IGNORE", "a, b")
     monkeypatch.setenv("SYNC_PRE_COMMIT_LOCK_PRE_COMMIT_FILE", ".test-config.yaml")
+    monkeypatch.setenv("SYNC_PRE_COMMIT_LOCK_HOOK_RUNNER", "prek")
     expected_config = SyncPreCommitLockConfig(
         automatically_install_hooks=False,
         disable_sync_from_lock=True,
         ignore=["a", "b"],
         pre_commit_config_file=".test-config.yaml",
         dependency_mapping={},
+        hook_runner=HookRunner.PREK,
     )
 
     actual_config = update_from_env(SyncPreCommitLockConfig())

--- a/tests/test_poetry/test_poetry_plugin.py
+++ b/tests/test_poetry/test_poetry_plugin.py
@@ -39,7 +39,7 @@ def test_handle_post_command_exit_code_not_zero() -> None:
 
 @patch("sync_pre_commit_lock.poetry_plugin.PoetrySetupPreCommitHooks.execute")
 @patch("sync_pre_commit_lock.config.toml.load", return_value={"tool": {"sync-pre-commit-lock": {}}})
-def test_handle_post_command_install_add_commands(mocked_execute: MagicMock, mock_load: MagicMock) -> None:
+def test_handle_post_command_install_add_commands(mock_load: MagicMock, mocked_execute: MagicMock) -> None:
     event = MagicMock(
         spec=ConsoleTerminateEvent,
         exit_code=0,
@@ -53,6 +53,9 @@ def test_handle_post_command_install_add_commands(mocked_execute: MagicMock, moc
     plugin._handle_post_command(event, event_name, dispatcher)
 
     mocked_execute.assert_called_once()
+    # toml.load is called twice: once for hook_runner config in _handle_post_command,
+    # once for plugin_config in run_sync_pre_commit_version
+    assert mock_load.call_count == 2
 
 
 def test_handle_post_command_self_command() -> None:
@@ -69,7 +72,7 @@ def test_handle_post_command_self_command() -> None:
 
 @patch("sync_pre_commit_lock.poetry_plugin.SyncPreCommitHooksVersion.execute")
 @patch("sync_pre_commit_lock.config.toml.load", return_value={"tool": {"sync-pre-commit-lock": {}}})
-def test_handle_post_command_install_add_lock_update_commands(mocked_execute: MagicMock, mock_load: MagicMock) -> None:
+def test_handle_post_command_install_add_lock_update_commands(mock_load: MagicMock, mocked_execute: MagicMock) -> None:
     event = MagicMock(
         spec=ConsoleTerminateEvent,
         exit_code=0,

--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,7 @@ deps =
     pdm27: pdm<2.8,>=2.7
     pdm28: pdm<2.9,>=2.8
     pdm29: pdm<2.10,>=2.9
-    pdmHEAD: pdm@ git+https://github.com/pdm-project/pdm.git
+    pdmHEAD: pdm @ git+https://github.com/pdm-project/pdm.git
 
 [testenv:py{314,313,312, 311, 310}-poetry{16, 17, 18, 20, 21, 22, 23,HEAD}]
 package = editable
@@ -90,7 +90,7 @@ deps =
     poetry21: poetry<2.2,>=2.1
     poetry22: poetry<2.3,>=2.2
     poetry23: poetry<2.4,>=2.3
-    poetryHEAD: poetry@ git+https://github.com/python-poetry/poetry.git
+    poetryHEAD: poetry @ git+https://github.com/python-poetry/poetry.git
 
 [gh]
 python =


### PR DESCRIPTION
Hello 👋🏼 

This PR completes #67 by supporting `prek` as a hook runner, aka. the tool used to install pre-commit hooks automatically.

It adds a `hook-runner` setting supporting the following values:
- `pre-commit`: the default for backward compatibility
- `prek`: choose a `prek` as hook runner
- `auto`: choose `prek` if available and fallback on `pre-commit` (useful for people using tools like `mise` as they can just install one of the 2 depending on the project and not have to set `hook-runner` for each project)
