### PR TITLE
fix(runner): HookRunner enum was not resolved from toml

### DIFF
--- a/src/sync_pre_commit_lock/config.py
+++ b/src/sync_pre_commit_lock/config.py
@@ -89,6 +89,10 @@ class SyncPreCommitLockConfig:
         metadata=Metadata(toml="hook-runner", env="HOOK_RUNNER", cast=HookRunner),
     )
 
+    def __post_init__(self) -> None:
+        if not isinstance(self.hook_runner, HookRunner):
+            self.hook_runner = HookRunner(self.hook_runner)
+
 
 def load_config(path: Path | None = None) -> SyncPreCommitLockConfig:
     """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,17 +12,20 @@ def test_from_toml() -> None:
         "ignore": ["a", "b"],
         "pre-commit-config-file": ".test-config.yaml",
         "dependency-mapping": {"pytest": {"repo": "pytest", "rev": "${ver}"}},
+        "hook-runner": "prek",
     }
     expected_config = SyncPreCommitLockConfig(
         disable_sync_from_lock=True,
         ignore=["a", "b"],
         pre_commit_config_file=".test-config.yaml",
         dependency_mapping={"pytest": RepoInfo(repo="pytest", rev="${ver}")},
+        hook_runner=HookRunner.PREK,
     )
 
     actual_config = from_toml(data)
 
     assert actual_config == expected_config
+    assert isinstance(actual_config.hook_runner, HookRunner)
 
 
 def test_update_from_env(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Hey 👋🏼 

A little fix on #73: when set from `pyproject.toml`, the config does not go through the cast mecanism and the `HookRunner` enum was not resolved.
This PR est and fix it