### PR TITLE
ci: pin GitHub Actions to SHAs and disable checkout credentials

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,13 @@
 version: 2
 updates:
 
-  # Maintain dependencies for GitHub Actions
+  # Maintain SHA-pinned GitHub Actions (Dependabot updates the commit SHA
+  # and trailing version comment together when a new release is available).
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Check built Python package
         id: baipp
-        uses: hynek/build-and-inspect-python-package@v2
+        uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
         with:
           upload-name-suffix: -${{ matrix.python-version }}-${{ matrix.os }}
           attest-build-provenance-github: ${{ github.event_name != 'pull_request' && !github.event.pull_request.head.repo.fork }}
@@ -60,10 +61,11 @@ jobs:
             pdm-version: ""
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
-      - uses: pdm-project/setup-pdm@v4
+          persist-credentials: false
+      - uses: pdm-project/setup-pdm@94a823180e06fcde4ad29308721954a521c96ed0 # v4.4
         name: Setup PDM
         with:
           cache: true
@@ -78,7 +80,7 @@ jobs:
           echo "PIP_CACHE=$(pip cache dir)" >> $GITHUB_OUTPUT
           echo "PDM_CACHE=$(pdm config cache_dir)" >> $GITHUB_OUTPUT
       - name: Cache PIP and PDM
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: |
             ${{ steps.set_variables.outputs.PIP_CACHE }}
@@ -93,7 +95,7 @@ jobs:
         run: pdm run tox
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,15 +13,17 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: pdm-project/setup-pdm@v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - uses: pdm-project/setup-pdm@94a823180e06fcde4ad29308721954a521c96ed0 # v4.4
       - name: Publish package distributions to PyPI
         run: pdm publish
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: dist
           path: ./dist/*
-      - uses: xresloader/upload-to-github-release@v1
+      - uses: xresloader/upload-to-github-release@7c5757a90c0bcf0c0e1741da8f2abd7b85e675d0 # v1.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/sync_python_deps.yml
+++ b/.github/workflows/sync_python_deps.yml
@@ -15,10 +15,12 @@ jobs:
   update-dependencies:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Update dependencies with PDM
-        uses: pdm-project/update-deps-action@main
+        uses: pdm-project/update-deps-action@22852fcff9a131d732730e8db92cc9502643a260 # v1.12
         with:
           # The personal access token, default: ${{ github.token }}
           token: ${{ github.token }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens CI against supply-chain and credential-persistence issues:

1. **Pin all GitHub Actions to full commit SHAs** (with version comments) across `ci.yml`, `release.yml`, and `sync_python_deps.yml`, including replacing `pdm-project/update-deps-action@main` with the `v1.12` SHA.
2. **Keep Dependabot** for `github-actions` — it already updates SHA-pinned actions (SHA + trailing version comment). Grouped weekly Action updates into a single PR. Renovate is not needed for this.
3. **Set `persist-credentials: false`** on every `actions/checkout` so the workflow token is not left in git config for later steps.

## Verification

- [x] **CI workflow runs on this PR** — [Python CI run](https://github.com/GabDug/sync-pre-commit-lock/actions/runs/31320277554) completed successfully (`Build & verify package` + all `CI-Python` matrix jobs on Ubuntu/macOS/Windows). CodeQL, pre-commit.ci, Snyk, and Codecov also passed.
- [x] **Dependabot `github-actions` entry present** — `.github/dependabot.yml` still has `package-ecosystem: github-actions` with weekly schedule + grouped updates. This repo already has an active Dependabot history for Actions bumps (e.g. #63, #65, #66, open #72/#75). Dependabot updates SHA-pinned refs and trailing version comments together, so no Renovate switch is required.
- [x] **Release / sync auth without checkout-persisted credentials**
  - `release.yml`: PyPI publish uses OIDC (`id-token: write`); release asset upload uses `GITHUB_TOKEN` / action `token` input via the GitHub API (`xresloader/upload-to-github-release`), not git credentials.
  - `sync_python_deps.yml`: `update-deps-action` passes `token: ${{ github.token }}` into `peter-evans/create-pull-request`, which configures its own HTTPS auth via `configureToken` (`x-access-token`) and does not rely on checkout-persisted credentials.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63b86cdb-7c79-4bec-a0b4-2615510f61bd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63b86cdb-7c79-4bec-a0b4-2615510f61bd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

