### PR TITLE
Set up Cursor Cloud dev environment (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`sync-pre-commit-lock` is a pure Python library/plugin (a PDM/Poetry plugin plus a
+standalone `sync-pre-commit-uv` CLI). There are **no long-running services, web
+servers, or databases** — "running the app" means running the CLI/plugin against a
+project's lockfile + `.pre-commit-config.yaml`, and "end-to-end testing" means the
+pytest suite.
+
+Dependencies are managed with **PDM** and installed into the project `.venv` by the
+startup update script (`pdm install -G :all --dev`). PDM is installed to
+`~/.local/bin`, which is added to `PATH` via `~/.bashrc`.
+
+### Lint / type-check / test / build (see `pyproject.toml` `[tool.pdm.scripts]`)
+- Lint: `pdm run lint-ruff` (ruff check) and `pdm run fmt` / `pdm run ruff format --check .`
+- Type-check: `pdm run lint-mypy` (mypy strict, `src/` only)
+- Test: `pdm run test` (pytest) — or `pdm run test-cov` for coverage
+- Full matrix (optional, slow, needs network + multiple Python versions): `pdm run test-all` (tox)
+- Build: `pdm build`
+
+### Non-obvious gotchas
+- **`NO_COLOR` / `FORCE_COLOR` env vars break 3 color tests.** The Cloud VM sets
+  `NO_COLOR=1` and `FORCE_COLOR=0` in the ambient environment. Because `use_color()`
+  honors `NO_COLOR`, three tests in `tests/test_shell_printer.py`
+  (`test_enable_colors_on_tty[True]`, `test_force_color[True]`, `test_force_color[False]`)
+  fail unless those vars are unset. Run the suite with them unset to get a clean pass:
+  `env -u NO_COLOR -u FORCE_COLOR pdm run test`. This is an environment quirk, not a
+  code bug — do not "fix" it in source.
+- The plugin installs itself editable via `[tool.pdm] plugins = ["-e ."]`, so `src/`
+  changes are picked up without reinstalling.
+- To try the plugin manually, copy a fixture project (e.g. `tests/fixtures/uv_project/`,
+  which has a `uv.lock` pinning `ruff` and a stale `.pre-commit-config.yaml`) to a temp
+  dir and run `.venv/bin/sync-pre-commit-uv` in it; it rewrites the config's `rev` to
+  match the lockfile. Supports `--dry-run`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up the development environment for `sync-pre-commit-lock` in Cursor Cloud and documents durable, non-obvious notes for future agents.

This project is a pure Python PDM/Poetry plugin + `sync-pre-commit-uv` CLI — no services, servers, or databases. "Running the app" means invoking the CLI/plugin against a lockfile + `.pre-commit-config.yaml`.

## Changes

- Add `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering lint/type-check/test/build commands and non-obvious gotchas.

## Environment setup (not code)

- PDM installed to `~/.local/bin` (added to `PATH` via `~/.bashrc`).
- Startup update script: `pdm install -G :all --dev` (installs deps + editable plugin into `.venv`; idempotent).

## Verification

| Check | Command | Result |
| --- | --- | --- |
| Lint | `pdm run lint-ruff` | All checks passed |
| Format | `pdm run ruff format --check .` | 27 files already formatted |
| Type-check | `pdm run lint-mypy` | Success, no issues in 14 files |
| Tests | `pdm run test` | 155 passed (see note) |

Note: 3 tests in `tests/test_shell_printer.py` fail only because the Cloud VM sets `NO_COLOR=1` / `FORCE_COLOR=0` in the ambient environment; `use_color()` honors `NO_COLOR`. Running with them unset (`env -u NO_COLOR -u FORCE_COLOR pdm run test`) yields a clean 155 passed. This is an environment quirk, not a code bug, and is documented in `AGENTS.md`.

## End-to-end demo

Ran the `sync-pre-commit-uv` CLI against a copy of `tests/fixtures/uv_project/` (lock pins `ruff 0.13.2`, config had stale `v0.1.0`). It detected and rewrote the config `rev` `v0.1.0 -> v0.13.2`, then reported idempotent on re-run.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a407eff0-fbbf-4850-87ec-033e6bbfb655?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a407eff0-fbbf-4850-87ec-033e6bbfb655&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

